### PR TITLE
Built the base structure for the media-downloader

### DIFF
--- a/edl.py
+++ b/edl.py
@@ -1,0 +1,71 @@
+import os
+import getpass
+import yt_dlp
+import time
+
+class Proksesor:
+    def __init__(self)-> None:
+    # Initializing the Download dir, user input will be taken in consideration
+        self.name = getpass.getuser()
+        self.download_path = input("Folder path: ")
+        self.ensure_download_path()
+
+    def ensure_download_path(self):
+    # Parsing to make sure the inputted dir exists.
+        if "~" in self.download_path:
+            self.download_path = self.download_path.replace('~/', f'/home/{self.name}/')
+
+
+        if not os.path.exists(self.download_path):
+            print("Invalid")
+            time.sleep(1)
+            print("Creating dir...")
+            time.sleep(3)
+            os.makedirs(self.download_path)
+        elif os.path.exists(self.download_path):
+            pass
+
+    def download_vid(self, url, codec):
+        
+        # Setting the downloader options
+        ydl_opts = {
+            'outtmpl': os.path.join(self.download_path, '%(title)s.%(ext)s'), # The output template of the downloaded file of the media
+            'format': 'bestaudio/best',
+            'postprocessors': [{
+                'key': 'FFmpegExtractAudio', # Extracts the audio from the video
+                'preferredcodec': codec,
+                'preferredquality': '320',
+            }],
+        }
+
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                print(f"Downloading video from {url}...")
+                ydl.download([url])
+        except Exception as e:
+            # Raised exception is caught as e, prints 'Error Downloading link: <error_message>'
+            print(f"Error Downloading link: {e}")
+
+    def run(self):
+    # UI interface/Prompts
+        print("Welcome to EDL")
+        while True:
+            self.download_path
+            self.ensure_download_path()
+            url = input("Input url (or 'exit' to quit): ")
+            if url.lower() == 'exit':
+                print("Leaving program...")
+                break
+            codec = input("Input Media format: ")
+            if url:
+                self.download_vid(url, codec)
+
+
+if __name__ == "__main__":
+    proks = Proksesor()
+    proks.run()
+
+
+
+
+

--- a/main.py
+++ b/main.py
@@ -1,1 +1,0 @@
-Hello World


### PR DESCRIPTION
Base structure allows the user to input a file location; '~/' gets interpreted as '/home/<OsUsername>/'. They're allowed to exit the program during the prompting for a url, they're also allowed to input the format of the media they want. Currently I want to solve the error of a media name being too long that program aborts it and prompts for a url once more.